### PR TITLE
fix dup-name issue for lblHeaderCleanups

### DIFF
--- a/content/rwh-prefs.js
+++ b/content/rwh-prefs.js
@@ -212,6 +212,7 @@ ReplyWithHeader.Prefs = {
       'hdrFontsize', 'lblFontcolor', 'hdrFontColor', 'lblSpace', 'lblBeforeHeader', 'spaceBeforeHdr',
       'lblAfterHeader', 'spaceAfterHdr', 'lblBeforeSeparator', 'spaceBeforeSep', 'lblSepLineSize', 'lblSepLineColor',
       'hdrSepLineSize', 'hdrSepLineColor', 'lblHeaderQuotSeq', 'quotSeqAttributionStyle', 'quotTimeAttributionStyle',
+      'lblHeaderCleanups',
       'transSubjectPrefix', 'lblNotAppBeforeSeparator', 'lblCntFormat', 'cleanBlockQuote', 'cleanNewBlockQuote',
       'cleanGreaterThanChar', 'lblHeaderFormat', 'excludePlainTextHdrPrefix', 'enableRwhDebugMode'
     ];

--- a/content/rwh-prefs.xul
+++ b/content/rwh-prefs.xul
@@ -203,7 +203,7 @@
                         <checkbox id="transSubjectPrefix" label="Transform subject prefix (Re -> RE and Fwd -> FW)" preference="pref-transSubjectPrefix" />
                     </hbox>
                     <hbox align="center" style="margin-top:5px">
-                        <label id="lblHeaderFormat" value="Header cleanups" />
+                        <label id="lblHeaderCleanups" value="Header cleanups" />
                     </hbox>
                     <hbox align="center" style="margin-left:15px">
                         <checkbox id="excludePlainTextHdrPrefix" label="Don't include plain text header prefix" preference="pref-excludePlainTextHdrPrefix" />


### PR DESCRIPTION
the name-dup causes the label for 'Header cleanups'
to remain 'on' when the 'Enable' checkbox is toggled 'off'