### PR TITLE
Add 'Lookout' mode for headers

### DIFF
--- a/content/rwh-prefs.xul
+++ b/content/rwh-prefs.xul
@@ -94,6 +94,7 @@
                         <radiogroup id="quotSeqAttributionStyle" preference="pref-quotSeqAttributionStyle"
                                     style="margin-left:30px">
                             <radio value="0" label="Default (Subject, Date, From, To, Cc)" />
+                            <radio value="3" label="Lookout (From, To, Cc, Date, Subject)" style="margin-top:-2px" />
                             <radio value="1" label="Outlook (From, Sent, To, Cc, Subject)" style="margin-top:-2px" />
                             <radio value="2" label="Simple (From, Sent, Subject)" style="margin-top:-2px" />
                         </radiogroup>

--- a/content/rwh.js
+++ b/content/rwh.js
@@ -431,6 +431,14 @@ var ReplyWithHeader = {
         if (pHeader.cc) {
           rwhHdr += htmlTagPrefix + '<b>' + i18n.cc[locale] + '</b> ' + pHeader.cc + htmlTagSuffix;
         }
+      } else if (headerQuotLblSeq == 3) {
+        rwhHdr += htmlTagPrefix + '<b>' + i18n.to[locale] + '</b> ' + pHeader.to + htmlTagSuffix;
+
+        if (pHeader.cc) {
+          rwhHdr += htmlTagPrefix + '<b>' + i18n.cc[locale] + '</b> ' + pHeader.cc + htmlTagSuffix;
+        }
+        rwhHdr += htmlTagPrefix + '<b>' + i18n.date[locale] + '</b> ' + pHeader.date + htmlTagSuffix;
+        rwhHdr += htmlTagPrefix + '<b>' + i18n.subject[locale] + '</b> ' + pHeader.subject + htmlTagSuffix;
       } else if (headerQuotLblSeq == 1) {
         rwhHdr += htmlTagPrefix + '<b>' + i18n.sent[locale] + '</b> ' + pHeader.date + htmlTagSuffix;
         rwhHdr += htmlTagPrefix + '<b>' + i18n.to[locale] + '</b> ' + pHeader.to + htmlTagSuffix;
@@ -469,6 +477,14 @@ var ReplyWithHeader = {
         if (pHeader.cc) {
           rwhHdr += i18n.cc[locale] + ' ' + pHeader.cc + '<br/>';
         }
+      } else if (headerQuotLblSeq == 3) {
+        rwhHdr += i18n.to[locale] + ' ' + pHeader.to + '<br/>';
+
+        if (pHeader.cc) {
+          rwhHdr += i18n.cc[locale] + ' ' + pHeader.cc + '<br/>';
+        }
+        rwhHdr += i18n.date[locale] + ' ' + pHeader.date + '<br/>';
+        rwhHdr += i18n.subject[locale] + ' ' + pHeader.subject + '<br/>';
       } else if (headerQuotLblSeq == 1) {
         rwhHdr += i18n.sent[locale] + ' ' + pHeader.date + '<br/>';
         rwhHdr += i18n.to[locale] + ' ' + pHeader.to + '<br/>';


### PR DESCRIPTION
add 'Lookout' mode for headers

the 'Lookout' mode is a mix of modes 'Outlook' and 'Default'
quoting as follows: From, To, Cc, Date, Subject

[note: this PR contains a single commit - if you merge ws PR #32 first]