### PR TITLE
Fix prefs dialog

### DIFF
--- a/content/rwh-prefs.xul
+++ b/content/rwh-prefs.xul
@@ -48,8 +48,8 @@
         <hbox align="center">
             <checkbox id="enableRwh" label="Enable" preference="pref-enableRwh"
                     oncommand="ReplyWithHeader.Prefs.toggleRwh();" />
-        </hbox>
-        <hbox align="right" style="margin-top:-27px;margin-right:3px;">
+            <spacer flex="1" />
+            <label id="lblLocale" value="Locale:" style="display: none" />
             <menulist id="hdrLocale" preference="pref-hdrLocale">
               <menupopup>
                   <menuitem label="English (en)" value="en" />


### PR DESCRIPTION
    1. the prefs dialog init fails in toggleRwh():
       code expects label 'lblLocale' to exist;
       having a label for the dropdown is "good" anyway :)
    
       => add label 'lblLocale' (with display:none)
    
    2. clicking the 'Enable' checkbox does nothing:
       the element does not take input, it is hidden by the dropdown hbox
    
       => move the Locale dropdown (and label) inside the 'Enable' hbox
          and use a spacer to right align


issue introduced by 4d42e93