### PR TITLE
add (back) var i18n in module rwh.js

### DIFF
--- a/content/rwh.js
+++ b/content/rwh.js
@@ -395,6 +395,7 @@ var ReplyWithHeader = {
     let rawHdr = this.getMsgHeader(this.messageUri);
     let pHeader = this.parseMsgHeader(rawHdr);
     let headerQuotLblSeq = this.Prefs.headerQuotLblSeq;
+    let i18n = this.i18n;
 
     var rwhHdr = '<div id="rwhMsgHeader">';
 


### PR DESCRIPTION
this [short-hand] var is required by header-generation code.

current master is broken, this fixes it.