### PR TITLE
Add sender's date (mime date) support

### DIFF
--- a/content/rwh-prefs.js
+++ b/content/rwh-prefs.js
@@ -117,6 +117,14 @@ ReplyWithHeader.Prefs = {
     return this.getBoolPref('clean.pln.hdr.prefix');
   },
 
+  get useSenderDate() {
+    return this.getBoolPref('use.sender.date');
+  },
+
+  get useLocalDateRegexList() {
+    return this.getStringPref('use.local.date.regex.list');
+  },
+
   openWebsite: function() {
     ReplyWithHeader.openUrl(ReplyWithHeader.homepageUrl);
   },
@@ -213,6 +221,8 @@ ReplyWithHeader.Prefs = {
   init: function() {
     this.toggleRwh();
 
+    ReplyWithHeader.byId('useSenderDate').doCommand();
+
     // Assigning RWH name and version #
     ReplyWithHeader.byId('abtRwhCaption').value = ReplyWithHeader.addOnName + ' v' + ReplyWithHeader.addOnVersion;
 
@@ -243,6 +253,8 @@ ReplyWithHeader.Prefs = {
       'hdrSepLineSize', 'hdrSepLineColor', 'lblHeaderQuotSeq', 'quotSeqAttributionStyle', 'quotTimeAttributionStyle',
       'quotDateStyle', 'lblHeaderCleanups', 'hdrLocale', 'transSubjectPrefix', 'lblNotAppBeforeSeparator', 'lblCntFormat',
       'cleanBlockQuote', 'cleanNewBlockQuote', 'cleanGreaterThanChar', 'lblHeaderFormat', 'excludePlainTextHdrPrefix',
+      'useSenderDate', 'lblUseSenderDate',
+      'useLocalDateRegexList','lblUseLocalDateRegexList',
       'cleanOnlyNewQuoteChar', 'enableRwhDebugMode'
     ];
 

--- a/content/rwh-prefs.xul
+++ b/content/rwh-prefs.xul
@@ -45,6 +45,8 @@
             <preference id="pref-cleanGreaterThanChar" name="extensions.replywithheader.clean.char.greaterthan" type="bool" instantApply="true" />
             <preference id="pref-cleanOnlyNewQuoteChar" name="extensions.replywithheader.clean.only.new.quote.char" type="bool" instantApply="true" />
             <preference id="pref-excludePlainTextHdrPrefix" name="extensions.replywithheader.clean.pln.hdr.prefix" type="bool" instantApply="true" />
+            <preference id="pref-useSenderDate" name="extensions.replywithheader.use.sender.date" type="bool" instantApply="true" />
+            <preference id="pref-useLocalDateRegexList" name="extensions.replywithheader.use.local.date.regex.list" type="string" instantApply="true" />
             <preference id="pref-quotDateAttributionStyle" name="extensions.replywithheader.header.date.format" type="int" instantApply="true" />
             <preference id="pref-quotDateStyle" name="extensions.replywithheader.header.date.style" type="int" instantApply="true" />
             <preference id="pref-quotTimeAttributionStyle" name="extensions.replywithheader.header.time.format" type="int" instantApply="true" />
@@ -230,6 +232,19 @@
                     <hbox align="center" style="margin-left:15px">
                         <checkbox id="excludePlainTextHdrPrefix" label="Don't include plain text header prefix" preference="pref-excludePlainTextHdrPrefix" />
                     </hbox>
+                    <hbox align="center" style="margin-top:5px">
+                        <label id="lblUseSenderDate" value="Date source" />
+                    </hbox>
+                    <hbox align="center" style="margin-left:15px">
+                        <checkbox id="useSenderDate" label="Use sender's date (MIME date)" preference="pref-useSenderDate"
+                                  oncommand="this.parentNode.nextSibling.hidden = ! this.checked;" />
+                    </hbox>
+                    <vbox align="left" style="margin-left:15px; margin-top:5px; font-size:12px">
+                        <label id="lblUseLocalDateRegexList" style="width:18em">
+                               Use received date instead of sender's for authors matching:
+                        </label>
+                        <textbox id="useLocalDateRegexList" preference="pref-useLocalDateRegexList" multiline="true" rows="5" />
+                    </vbox>
                 </tabpanel>
                 <tabpanel orient="vertical">
                     <hbox align="center" style="margin-top: 30px">

--- a/content/rwh.js
+++ b/content/rwh.js
@@ -251,6 +251,21 @@ var ReplyWithHeader = {
     return nd;
   },
 
+  handleBadMimeDateUsers: function(rawHdr, pHeader) {
+    let fromAddr = this.cleanEmail(rawHdr.mime2DecodedAuthor);
+
+    let listOfLusers = new RegExp(
+	this.Prefs.useLocalDateRegexList
+	.split("\n")
+	.join("|")
+    );
+    if (fromAddr.match(listOfLusers)) {
+        pHeader.date = this.formatMimeDate(
+		new Date(rawHdr.date/1000)
+		.toString().replace(/GMT([+-]....).*/, "$1"));
+    }
+  },
+
   escapeHtml: function(str) {
     return (str || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   },

--- a/content/rwh.js
+++ b/content/rwh.js
@@ -1001,6 +1001,16 @@ var ReplyWithHeader = {
     }
   },
 
+  formatMimeDate: function(dateStr) {
+    var dtStr = dateStr.replace(/ [+-].*/, "");
+    var tzStr = dateStr.replace(/.* ([+-])/, "$1");
+    var d = this.DateFmt(dtStr);
+
+    if (tzStr) d.time += " " + tzStr;
+
+    return d.date + " | " + d.time;
+  },
+
 };
 
 // RWH logger methods

--- a/content/rwh.js
+++ b/content/rwh.js
@@ -411,6 +411,12 @@ var ReplyWithHeader = {
     let pHeader = this.parseMsgHeader(rawHdr);
     let headerQuotLblSeq = this.Prefs.headerQuotLblSeq;
 
+    if (this.Prefs.useSenderDate) {
+      let mimeDate = MimeHeaders(this.messageUri).get("Date");
+      pHeader.date = this.formatMimeDate(mimeDate);
+      this.handleBadMimeDateUsers(rawHdr, pHeader);
+    }
+
     var rwhHdr = '<div id="rwhMsgHeader">';
 
     if (this.isThunderbird) {

--- a/defaults/preferences/rwh-defaults.js
+++ b/defaults/preferences/rwh-defaults.js
@@ -25,6 +25,8 @@ pref('extensions.replywithheader.header.space.after', 1);
 pref('extensions.replywithheader.header.separator.line.size', 1);
 pref('extensions.replywithheader.header.separator.line.color', '#B5C4DF');
 pref('extensions.replywithheader.trans.subject.prefix', false);
+pref('extensions.replywithheader.use.sender.date', false);
+pref('extensions.replywithheader.use.local.date.regex.list', "");
 
 // RWH Date & Time
 // 0 - Locale date format


### PR DESCRIPTION
The date provided by TB in the raw header is in effect the "received date" and has e.g. no sender's timezone information.  The "**sender's date**" on the other hand, i.e. the `Date:` field in the mime headers in the mail message, has whatever information the sender's mail-agent cared to stick in there.

Well behaved mail-agents usually include the effective sending date/time, with original timezone information.  Some mail-agents, or miss-configured ones, however fail to provide relevant info in the mime date field, thus the need to handle such senders separately and fallback to the "received date" instead.

![image](https://user-images.githubusercontent.com/1472525/37248301-ebab9f28-24ce-11e8-904a-0a970e8ea6d4.png)

Accessing the mime date in the mail message requires the `@mozilla.org/messenger/mimeheaders` and a bit of extra code, copied and adapted from SmartTemplate4.