### PR TITLE
Add per-account header language auto selection

### DIFF
--- a/content/rwh-prefs.js
+++ b/content/rwh-prefs.js
@@ -97,6 +97,14 @@ ReplyWithHeader.Prefs = {
     return this.getBoolPref('trans.subject.prefix');
   },
 
+  get autoSelectLang() {
+    return this.getBoolPref('auto.select.lang');
+  },
+
+  get autoSelectLangRegexList() {
+    return this.getStringPref('auto.select.lang.regex.list');
+  },
+
   get cleanBlockQuote() {
     return this.getBoolPref('clean.blockquote');
   },
@@ -227,6 +235,7 @@ ReplyWithHeader.Prefs = {
 
     this.toggleBlockQuote();
     this.toggleQuoteChar();
+    ReplyWithHeader.byId('autoSelectLang').doCommand();
 
     this.forPostbox(true);
 
@@ -242,6 +251,8 @@ ReplyWithHeader.Prefs = {
       'lblAfterHeader', 'spaceAfterHdr', 'lblBeforeSeparator', 'spaceBeforeSep', 'lblSepLineSize', 'lblSepLineColor',
       'hdrSepLineSize', 'hdrSepLineColor', 'lblHeaderQuotSeq', 'quotSeqAttributionStyle', 'quotTimeAttributionStyle',
       'quotDateStyle', 'lblHeaderCleanups', 'hdrLocale', 'transSubjectPrefix', 'lblNotAppBeforeSeparator', 'lblCntFormat',
+      'autoSelectLang', 'lblAutoSelectLang',
+      'autoSelectLangRegexList', 'lblAutoSelectLangRegexList',
       'cleanBlockQuote', 'cleanNewBlockQuote', 'cleanGreaterThanChar', 'lblHeaderFormat', 'excludePlainTextHdrPrefix',
       'cleanOnlyNewQuoteChar', 'enableRwhDebugMode'
     ];

--- a/content/rwh-prefs.xul
+++ b/content/rwh-prefs.xul
@@ -39,6 +39,8 @@
             <preference id="pref-spaceAfterHdr" name="extensions.replywithheader.header.space.after" type="int" instantApply="true" />
             <preference id="pref-hdrSepLineSize" name="extensions.replywithheader.header.separator.line.size" type="int" instantApply="true" />
             <preference id="pref-hdrSepLineColor" name="extensions.replywithheader.header.separator.line.color" type="string" instantApply="true" />
+            <preference id="pref-autoSelectLang" name="extensions.replywithheader.auto.select.lang" type="bool" instantApply="true" />
+            <preference id="pref-autoSelectLangRegexList" name="extensions.replywithheader.auto.select.lang.regex.list" type="string" instantApply="true" />
             <preference id="pref-transSubjectPrefix" name="extensions.replywithheader.trans.subject.prefix" type="bool" instantApply="true" />
             <preference id="pref-cleanBlockQuote" name="extensions.replywithheader.clean.blockquote" type="bool" instantApply="true" />
             <preference id="pref-cleanNewBlockQuote" name="extensions.replywithheader.clean.new.blockquote" type="bool" instantApply="true" />
@@ -201,6 +203,17 @@
                     </hbox>
                 </tabpanel>
                 <tabpanel orient="vertical">
+                    <hbox align="center">
+                        <label id="lblAutoSelectLang" value="Automatic language selection" />
+                    </hbox>
+                    <hbox align="center" style="margin-left:15px">
+                        <checkbox id="autoSelectLang" label="Select language based on account's email" preference="pref-autoSelectLang"
+                                  oncommand="this.parentNode.nextSibling.hidden = ! this.checked;" />
+                    </hbox>
+                    <vbox align="left" style="margin-left:15px; margin-top:5px; font-size:12px">
+                        <label id="lblAutoSelectLangRegexList" value="email => language mappings"/>
+                        <textbox id="autoSelectLangRegexList" preference="pref-autoSelectLangRegexList" multiline="true" rows="2" />
+                    </vbox>
                     <hbox id="hboxCntFormat" align="center">
                         <label id="lblCntFormat" value="Content formatting and cleanups" />
                     </hbox>

--- a/content/rwh.js
+++ b/content/rwh.js
@@ -390,8 +390,34 @@ var ReplyWithHeader = {
     return header;
   },
 
+  getLocaleForAccount: function() {
+    var from = gMsgCompose.compFields.from;
+    var list = this.Prefs.autoSelectLangRegexList.split("\n");
+
+    for (var entry in list) {
+      entry = list[entry].match(/(.*) => (..)/);
+      if (! entry) continue;
+
+      var spec = entry[1];
+      var lang = entry[2].toLowerCase();
+
+      if (! i18n.lang[lang]) continue;
+      if (! from.match(spec)) continue;
+
+      return lang;
+    }
+    return this.Prefs.headerLocale;
+  },
+
+  setLocale: function() {
+    if (this.Prefs.autoSelectLang)
+      return this.locale = this.getLocaleForAccount();
+    else
+      return this.locale = this.Prefs.headerLocale;
+  },
+
   get createRwhHeader() {
-    let locale = this.Prefs.headerLocale;
+    let locale = this.setLocale();
     let rawHdr = this.getMsgHeader(this.messageUri);
     let pHeader = this.parseMsgHeader(rawHdr);
     let headerQuotLblSeq = this.Prefs.headerQuotLblSeq;
@@ -988,7 +1014,7 @@ var ReplyWithHeader = {
         minute: "numeric",
         hour12: (this.Prefs.timeFormat == 0),
     };
-    var locale = this.Prefs.headerLocale;
+    var locale = this.locale;
 
     date = new Date(date);
 

--- a/defaults/preferences/rwh-defaults.js
+++ b/defaults/preferences/rwh-defaults.js
@@ -24,6 +24,8 @@ pref('extensions.replywithheader.header.space.before', 0);
 pref('extensions.replywithheader.header.space.after', 1);
 pref('extensions.replywithheader.header.separator.line.size', 1);
 pref('extensions.replywithheader.header.separator.line.color', '#B5C4DF');
+pref('extensions.replywithheader.auto.select.lang', false);
+pref('extensions.replywithheader.auto.select.lang.regex.list', "");
 pref('extensions.replywithheader.trans.subject.prefix', false);
 
 // RWH Date & Time


### PR DESCRIPTION
Add ability to define header language based on sending account's email.

- add Prefs > Misc > Automatic language selection
- add selection logic


![image](https://user-images.githubusercontent.com/1472525/37248167-66354302-24ca-11e8-9e83-8a802e91263b.png)
