### PR TITLE
Fix 'empty-from' issue

### DIFF
--- a/content/rwh.js
+++ b/content/rwh.js
@@ -406,7 +406,7 @@ var ReplyWithHeader = {
   },
 
   getLocaleForAccount: function() {
-    var from = gMsgCompose.compFields.from;
+    var from = document.getElementById("msgIdentity").value;
     var list = this.Prefs.autoSelectLangRegexList.split("\n");
 
     for (var entry in list) {


### PR DESCRIPTION
Fix 'empty-from' issue  (closes #53)

gMsgCompose.compFields.from is sometimes empty
document.getElementById(msgIdentity).value works better
