### PR TITLE
Dual languages locale drop-down

### DIFF
--- a/content/rwh-i18n.js
+++ b/content/rwh-i18n.js
@@ -3,12 +3,12 @@
 var i18n = {
   "lang": {
     "en": "English",
-    "fr": "French",
-    "de": "German",
-    "es": "Spanish",
-    "jp": "Japanese",
+    "fr": "French - Français",
+    "de": "German - Deutsch",
+    "es": "Spanish - Español",
+    "jp": "Japanese - 日本語",
     "pl": "Polish",
-    "ar": "Arabic",
+    "ar": "Arabic - العربية",
     "pt": "Portuguese",
   },
   "from": {

--- a/content/rwh-i18n.js
+++ b/content/rwh-i18n.js
@@ -7,9 +7,9 @@ var i18n = {
     "de": "German - Deutsch",
     "es": "Spanish - Español",
     "jp": "Japanese - 日本語",
-    "pl": "Polish",
+    "pl": "Polish - Polski",
     "ar": "Arabic - العربية",
-    "pt": "Portuguese",
+    "pt": "Portuguese - Português",
   },
   "from": {
     "en": "From:",


### PR DESCRIPTION
Add dual-language "locale" drop-down labels (suggested by @Valerie-Yuuki)

Updated "lang" labels:
- `fr  de  es  ar  jp`   (Valerie-Yuuki)
- `pl pt` (ofa-)