### PR TITLE
Wrong Dutch Translation (see issue #106)

### DIFF
--- a/chrome/content/i18n.js
+++ b/chrome/content/i18n.js
@@ -146,7 +146,7 @@ var i18n = {
     "pt": "Enviado:",
     "pt-BR": "Enviado:",
     "ko": "보낸 날짜:",
-    "nl": "Datum:",
+    "nl": "Verzonden:",
     "nb": "Sendt:",
     "ru": "Отправлено:",
     "sv": "Skickat",


### PR DESCRIPTION
The Outlook header style contains the english 'sent'
This is currently translated to Dutch with 'Datum'
However, it should be translated with 'Verzonden'
Can you change that?