### PR TITLE
Remove all <...> text blocks in replies

### DIFF
--- a/chrome/content/core.js
+++ b/chrome/content/core.js
@@ -825,6 +825,9 @@ var ReplyWithHeader = {
       } else {
         mailBody.innerHTML = mailBody.innerHTML.replace(/<br>(&gt;)+ ?/g, '<br>').replace(/(<\/?span [^>]+>)(&gt;)+ /g, '$1');
       }
+
+      // remove all <...> text blocks ( &lt; whatever &gt; ) in mail body
+      mailBody.innerHTML = mailBody.innerHTML.replaceAll(/(&lt;)((?!&gt;).)*(&gt;)+/g, '');
     }
   },
 


### PR DESCRIPTION
I noticed that in TB 102.11.0 (at least, on Ubuntu) I get mangled links and email addresses in plain-text replies to HTML mails. It looks as though TB is adding blocks of the form `<link>` or `<email>` to links or emails in the original HTML email when converting it to plain text; and this gets nested with replies piling up.

This single-commit PR removes the extraneous bloat in plain-text replies.