### PR TITLE
Add GitHub Action to create a new Release with xpi attachment on new tag push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,33 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  build_release:
+    name: build_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: GIT checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Read version from manifest.json
+        run: echo "VERSION=$(grep '"version":' manifest.json | tr --delete '" ,' | sed 's/version://')" >> $GITHUB_OUTPUT
+        id: version
+      - name: Build changelog since last tag
+        id: changelog
+        run: |
+          git log --oneline $(git describe --tags --abbrev=0 @^)..@ > Changelog.tmp
+      - name: Build artifacts
+        run: zip -r replywithheader-v${{ steps.version.outputs.VERSION }}.xpi * -x ".*"
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/') # Only run for new tags
+        with:
+          body_path: Changelog.tmp
+          files: |
+            replywithheader-v${{ steps.version.outputs.VERSION }}.xpi


### PR DESCRIPTION
(re-opened because GitHub force closed the earlier one at #132)

This PR adds a GitHub action that, every time a tag is pushed, will create a new Release with the .xpi attached. The Release will have an automatically generated changelog with the short log of all commits since the previous release. Additionally, the associated .xpi file will be attached to the Release.

For a preview of the final result, check out the [Releases page](https://github.com/frazar/ReplyWithHeaderMozilla/releases) of my fork. 

Note that, for the GitHub action to work, read and write permissions must be granted. This can be done in `Settings` > `Actions` > `General` > `Workflow permissions` by choosing `Read and write permissions`.
